### PR TITLE
switch to query Thanos querier 

### DIFF
--- a/charts/kubex-collection-openshift/Chart.yaml
+++ b/charts/kubex-collection-openshift/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 description: Kubex Collection Stack for OpenShift Clusters
 name: kubex-collection-openshift
-version: 1.0.2
+version: 1.0.3
 type: application
 icon: https://kubex.ai/wp-content/uploads/kubex-logo-landscape.svg
 dependencies:

--- a/charts/kubex-collection-openshift/values.yaml
+++ b/charts/kubex-collection-openshift/values.yaml
@@ -21,7 +21,7 @@ container-optimization-data-forwarder:
     prometheus:
       url:
         scheme: https
-        host: prometheus-k8s.openshift-monitoring.svc
+        host: thanos-querier.openshift-monitoring.svc
         port: 9091
       # OpenShift Service CA Operator ca cert
       ca_cert: /var/run/secrets/kubernetes.io/serviceaccount/service-ca.crt


### PR DESCRIPTION
To allow other exporters as user-workload monitoring (DCGM, epehemral storage etc.)