### PR TITLE
fix: resolve valkey Helm warnings and OpenShift compatibility issues

### DIFF
--- a/charts/kubex-automation-controller/Chart.yaml
+++ b/charts/kubex-automation-controller/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: kubex-automation-controller
 description: "A Helm chart for deploying Kubex Automation Controller"
 type: application
-version: 1.0.12
+version: 1.0.13
 icon: https://www.kubex.ai/wp-content/uploads/kubex-by-densify-logo.png
 dependencies:
   - name: valkey

--- a/charts/kubex-automation-controller/templates/deployment.yaml
+++ b/charts/kubex-automation-controller/templates/deployment.yaml
@@ -135,6 +135,8 @@ spec:
           securityContext:
             {{- toYaml . | nindent 12 }}
           {{- end }}
+          resources:
+            {{- toYaml .Values.deployment.initContainerResources | nindent 12 }}
         - name: kubex-automation-gw
           image: {{ .Values.deployment.gatewayImage | quote }}
           imagePullPolicy: Always
@@ -307,6 +309,8 @@ spec:
           securityContext:
             {{- toYaml . | nindent 12 }}
           {{- end }}
+          resources:
+            {{- toYaml .Values.deployment.initContainerResources | nindent 12 }}
         - name: kubex-webhook-gw
           image: {{ .Values.deployment.gatewayImage | quote }}
           imagePullPolicy: Always

--- a/charts/kubex-automation-controller/values-openshift.yaml
+++ b/charts/kubex-automation-controller/values-openshift.yaml
@@ -2,12 +2,44 @@ openshift:
   enabled: true
 
 # Valkey subchart overrides for OpenShift compatibility.
+# Omit fixed UID/GID and seccomp - let OpenShift assign them dynamically.
 valkey:
   serviceAccount:
     create: true
     name: kubex-valkey-sa
-  podSecurityContext: null
-  securityContext: null
+  # Resources for valkey-init initContainer (required by OpenShift)
+  initResources:
+    requests:
+      memory: "32Mi"
+      cpu: "50m"
+    limits:
+      memory: "64Mi"
+  podSecurityContext:
+    fsGroup: null
+    supplementalGroups: null
+    seccompProfile: null
+  securityContext:
+    allowPrivilegeEscalation: false
+    privileged: false
+    readOnlyRootFilesystem: true
+    runAsNonRoot: true
+    runAsUser: null
+    runAsGroup: null
+    seccompProfile: null
+    capabilities:
+      drop:
+        - ALL
   metrics:
     exporter:
-      securityContext: null
+      securityContext:
+        allowPrivilegeEscalation: false
+        privileged: false
+        readOnlyRootFilesystem: true
+        runAsNonRoot: true
+        runAsUser: null
+        runAsGroup: null
+        seccompProfile: null
+        capabilities:
+          drop:
+            - ALL
+

--- a/charts/kubex-automation-controller/values.yaml
+++ b/charts/kubex-automation-controller/values.yaml
@@ -96,6 +96,13 @@ deployment:
     capabilities:
       drop:
         - ALL
+  # Resource specifications for init containers
+  initContainerResources:
+    requests:
+      memory: "32Mi"
+      cpu: "50m"
+    limits:
+      memory: "64Mi"
   controllerEnv: # Environment variables for the controller pod
     podScanInitialInterval: "2m"  # Initial delay before first pod scan after startup
     podScanInterval: "1h"  # Default optimized for in-place resizing (Kubernetes 1.33+). See Pod-Scan-Configuration.md for pod eviction mode settings.
@@ -193,13 +200,48 @@ valkey:
   # Add password to valkey.conf via a Secret file
   extraSecretValkeyConfigs: kubex-valkey-secret
 
+  # Resources for valkey-init initContainer
+  initResources:
+    requests:
+      memory: "32Mi"
+      cpu: "50m"
+    limits:
+      memory: "64Mi"
+
+  # Complete pod security context for valkey (default for non-OpenShift)
   podSecurityContext:
+    fsGroup: 999
+    supplementalGroups:
+      - 999
     seccompProfile:
       type: RuntimeDefault
 
+  # Complete container security context for valkey (default for non-OpenShift)
   securityContext:
+    allowPrivilegeEscalation: false
+    privileged: false
+    readOnlyRootFilesystem: true
+    runAsNonRoot: true
+    runAsUser: 999
+    runAsGroup: 999
+    capabilities:
+      drop:
+        - ALL
     seccompProfile:
       type: RuntimeDefault
+
+  # OpenShift-specific pod security context (omit fixed UID/GID and seccomp)
+  podSecurityContextOpenShift: {}
+
+  # OpenShift-specific container security context
+  securityContextOpenShift:
+    allowPrivilegeEscalation: false
+    privileged: false
+    readOnlyRootFilesystem: true
+    runAsNonRoot: true
+    capabilities:
+      drop:
+        - ALL
 
   # Storage for single-instance (non-HA)
   storage:
@@ -233,9 +275,28 @@ valkey:
   metrics:
     enabled: true
     exporter:
+      # Complete security context for metrics exporter (default for non-OpenShift)
       securityContext:
+        allowPrivilegeEscalation: false
+        privileged: false
+        readOnlyRootFilesystem: true
+        runAsNonRoot: true
+        runAsUser: 999
+        runAsGroup: 999
+        capabilities:
+          drop:
+            - ALL
         seccompProfile:
           type: RuntimeDefault
+      # OpenShift-specific security context for metrics exporter
+      securityContextOpenShift:
+        allowPrivilegeEscalation: false
+        privileged: false
+        readOnlyRootFilesystem: true
+        runAsNonRoot: true
+        capabilities:
+          drop:
+            - ALL
       image:
         registry: docker.io
         repository: oliver006/redis_exporter


### PR DESCRIPTION
- Provide complete security contexts to fix Helm coalesce warnings
- Add initContainer resources to satisfy OpenShift admission requirements
- Remove fixed UIDs/GIDs from valkey for OpenShift SCC compatibility
- Bump chart version to 1.0.13

Fixes:
- Helm coalesce.go:298 warnings for valkey.podSecurityContext and valkey.securityContext
- OpenShift admission warning for missing initContainer resource requests/limits
- Valkey pod creation failures on OpenShift due to restricted UID ranges