### PR TITLE
feat: add VPA exclusion to prevent autoscaler conflicts

### DIFF
--- a/charts/kubex-automation-controller/README.md
+++ b/charts/kubex-automation-controller/README.md
@@ -39,7 +39,7 @@ The deployment consists of several key services:
 
 - **🚀 Automated Resizing**: Dynamic CPU and memory optimization based on actual usage patterns
 - **⚡ Zero-Downtime Optimization**: In-place container resizing without pod restarts (Kubernetes 1.33+) with automatic fallback to pod eviction
-- **🛡️ Safety-First Approach**: Multi-layered validation including HPA awareness, LimitRange compliance, ResourceQuota checking, node allocatable capacity validation, PodDisruptionBudget respect, and configurable pod eviction delays
+- **🛡️ Safety-First Approach**: Multi-layered validation including HPA/VPA awareness, LimitRange compliance, ResourceQuota checking, node allocatable capacity validation, PodDisruptionBudget respect, and configurable pod eviction delays
 - **⏸️ Smart Pause Control**: Per-pod annotation-based pausing for learning periods after application changes or permanent exclusions
 - **📋 Policy-Driven**: Configurable automation rules for downsizing, upsizing, and constraint handling
 - **🎯 Flexible Targeting**: Multiple scope configurations for different automation behaviors across cluster regions

--- a/charts/kubex-automation-controller/docs/Advanced-Configuration.md
+++ b/charts/kubex-automation-controller/docs/Advanced-Configuration.md
@@ -12,6 +12,9 @@ This guide covers advanced configuration options for the Kubex Automation Contro
     - [Time-Based Pause](#time-based-pause)
     - [Behavior](#behavior)
     - [Use Cases](#use-cases)
+  - [Autoscaler Compatibility](#autoscaler-compatibility)
+    - [Vertical Pod Autoscaler (VPA) Exclusion](#vertical-pod-autoscaler-vpa-exclusion)
+    - [Horizontal Pod Autoscaler (HPA) Awareness](#horizontal-pod-autoscaler-hpa-awareness)
   - [Node Scheduling Configuration](#node-scheduling-configuration)
     - [Configuring Node Affinity](#configuring-node-affinity)
     - [Common Scheduling Patterns](#common-scheduling-patterns)
@@ -158,6 +161,71 @@ spec:
       - name: daemon
         # ... container spec
 ```
+
+---
+
+## Autoscaler Compatibility
+
+Kubex Automation Controller automatically detects and excludes workloads managed by other autoscaling solutions to prevent conflicts and ensure safe coexistence.
+
+### Vertical Pod Autoscaler (VPA) Exclusion
+
+The controller **automatically detects** workloads managed by VerticalPodAutoscaler and excludes them from Kubex automation. This prevents two systems from competing to manage the same resources.
+
+**How it works:**
+1. Controller scans for VPA objects in the cluster
+2. Workloads referenced by any VPA are automatically excluded
+3. No manual configuration required
+
+**Example - VPA-managed workload (automatically excluded):**
+```yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: my-app
+  namespace: production
+spec:
+  template:
+    spec:
+      containers:
+      - name: app
+        resources:
+          requests:
+            cpu: 100m
+            memory: 128Mi
+---
+# This VPA object causes the deployment above to be excluded from Kubex automation
+apiVersion: autoscaling.k8s.io/v1
+kind: VerticalPodAutoscaler
+metadata:
+  name: my-app-vpa
+  namespace: production
+spec:
+  targetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: my-app
+  updatePolicy:
+    updateMode: "Auto"
+```
+
+**Verification:**
+```bash
+# List VPA objects in your cluster
+kubectl get vpa -A
+
+# Check controller logs for VPA exclusion messages
+kubectl logs -n kubex deployment/kubex-automation-controller -c kubex-automation-controller | grep -i vpa
+```
+
+### Horizontal Pod Autoscaler (HPA) Awareness
+
+The controller is HPA-aware and skips workloads with active HPAs that scale on CPU and/or memory metrics to avoid interference.
+
+**Best practices:**
+- VPA and Kubex automation are mutually exclusive - choose one per workload
+- HPA and Kubex can coexist - Kubex will not resize pods when HPA is actively scaling on CPU/memory
+- Use VPA for vertical scaling, HPA for horizontal scaling, or Kubex for policy-driven right-sizing
 
 ---
 

--- a/charts/kubex-automation-controller/docs/FAQ.md
+++ b/charts/kubex-automation-controller/docs/FAQ.md
@@ -200,6 +200,7 @@ scope:
 ### Q: Can the controller damage my applications?
 **A:** Multiple safety mechanisms prevent damage:
 - **HPA awareness**: Won't resize if HPA is actively scaling on CPU and/or memory
+- **VPA exclusion**: Automatically detects and excludes workloads managed by VerticalPodAutoscaler to prevent conflicts
 - **PodDisruptionBudget**: Respects PDB constraints before eviction
 - **ResourceQuota checking**: Ensures changes don't violate quotas
 - **LimitRange validation**: Checks namespace limits before applying changes
@@ -229,6 +230,34 @@ scope:
 
 ### Q: Does this work with GitOps?
 **A:** Yes! Configure your GitOps tool to ignore resource request/limit changes. See [GitOps Integration Guide](./GitOps-Integration.md) for Argo CD, Flux, and OpenShift GitOps.
+
+### Q: Can I use this with VerticalPodAutoscaler (VPA)?
+**A:** Kubex Automation and VPA should not manage the same workloads simultaneously. The controller **automatically detects and excludes** any workload referenced by a VPA object to prevent conflicts.
+
+**How it works:**
+- Controller scans for VPA objects across all namespaces
+- Workloads with VPA are automatically excluded from Kubex automation
+- No manual configuration needed
+
+**Example:**
+```yaml
+# This deployment is automatically excluded from Kubex if a VPA targets it
+apiVersion: autoscaling.k8s.io/v1
+kind: VerticalPodAutoscaler
+metadata:
+  name: my-app-vpa
+spec:
+  targetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: my-app
+```
+
+**Choose the right tool:**
+- **VPA**: Best for workloads where you want Kubernetes to automatically adjust resources based on real-time usage
+- **Kubex Automation**: Best for policy-driven optimization with enterprise features like HPA awareness, PDB respect, and granular control over upsize/downsize behavior
+
+See [Advanced Configuration - Autoscaler Compatibility](./Advanced-Configuration.md#autoscaler-compatibility) for more details.
 
 ---
 

--- a/charts/kubex-automation-controller/docs/Troubleshooting.md
+++ b/charts/kubex-automation-controller/docs/Troubleshooting.md
@@ -109,6 +109,7 @@ kubectl get configmap kubex-automation-policy -n kubex -o yaml
 - **Policy restrictions**: Check if automation is globally enabled
 - **Resource quota limits**: Controller may skip optimizations if quota headroom is insufficient
 - **HPA conflicts**: Controller skips pods with active HPAs on CPU/memory metrics
+- **VPA conflicts**: Controller automatically excludes workloads managed by VerticalPodAutoscaler
 - **RBAC permission denied**: Verify ClusterRole and ClusterRoleBinding are properly configured
 - **Cross-namespace access issues**: Controller requires cluster-wide permissions to validate resources
 
@@ -137,6 +138,9 @@ kubectl get configmap kubex-automation-policy -n kubex -o yaml
    ```bash
    # Check for active HPAs on CPU/memory
    kubectl get hpa -A
+   
+   # Check for VPA objects (workloads with VPA are automatically excluded)
+   kubectl get vpa -A
    
    # Check PodDisruptionBudgets
    kubectl get pdb -A

--- a/charts/kubex-automation-controller/values.yaml
+++ b/charts/kubex-automation-controller/values.yaml
@@ -34,7 +34,7 @@ webhook:
 deployment:
   webhookImage: densify/container-automation:1.4 # Container image for the Kubex automation webhook server.
   gatewayImage: densify/automation-gateway:1.1 # Container image for the Kubex automation gateway.
-  controllerImage: densify/automation-director:1.2 # Container image for the Kubex automation controller.
+  controllerImage: densify/automation-director:1.3 # Container image for the Kubex automation controller.
   waitForValkeyImage: busybox:latest
 
   replicas: # Number of pod replicas to run ([set >1 for high availability).


### PR DESCRIPTION
Add automatic VerticalPodAutoscaler detection and exclusion to prevent Kubex Automation from competing with VPA for resource management.

Changes:
- Controller now scans for VPA objects and excludes referenced workloads
- No manual configuration required - fully automatic
- Prevents conflicts between VPA and Kubex automation
- Documentation added across README, FAQ, Troubleshooting, and Advanced Configuration