### PR TITLE
Add the node-labeler within the stack (disabled by default)

### DIFF
--- a/charts/kubex-automation-stack/Chart.lock
+++ b/charts/kubex-automation-stack/Chart.lock
@@ -5,5 +5,8 @@ dependencies:
 - name: prometheus
   repository: https://prometheus-community.github.io/helm-charts
   version: 27.52.0
-digest: sha256:93ff613a57857914ebde2219cd43b60ffeb0aa3f555fedaac29d9919b25efaf8
-generated: "2026-01-29T21:53:16.935264955Z"
+- name: node-labeler
+  repository: https://densify-dev.github.io/helm-charts
+  version: 0.1.0
+digest: sha256:4ea130ce287e78882c6c94c4ca2347bd8c7d5e46c42de02157e50b13edbc60ec
+generated: "2026-02-19T15:14:46.659633251Z"

--- a/charts/kubex-automation-stack/Chart.yaml
+++ b/charts/kubex-automation-stack/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 description: Kubex Collection Stack
 name: kubex-automation-stack
-version: 1.0.2
+version: 1.0.3
 type: application
 icon: https://www.kubex.ai/wp-content/uploads/kubex-by-densify-logo.png
 dependencies:

--- a/charts/kubex-automation-stack/Chart.yaml
+++ b/charts/kubex-automation-stack/Chart.yaml
@@ -11,6 +11,10 @@ dependencies:
   - name: prometheus
     version: "27.*.*"
     repository: https://prometheus-community.github.io/helm-charts
+  - name: node-labeler
+    version: "0.1.0"
+    repository: https://densify-dev.github.io/helm-charts
+    condition: node-labeler.enabled
 keywords:
 - kubex
 - densify

--- a/charts/kubex-automation-stack/README.md
+++ b/charts/kubex-automation-stack/README.md
@@ -69,6 +69,7 @@ The following table lists configuration parameters in `values-edit.yaml`.
 | `container-optimization-data-forwarder.`<br/>`cronJob.ttlSecondsAfterFinished` |                    | TTL to keep jobs after completion/failure |
 | `container-optimization-data-forwarder.`<br/>`cronJob.backoffLimit` |                    | Backoff limit for jobs |
 | `prometheus.server.persistentVolume.`<br/>`storageClass`                         |                    | Storage class for Prometheus persistent volume |
+| `node-labeler.enabled`                                                           |                    | Enable optional node-labeler subchart (`false` by default) |
 
 ## Limitations
 
@@ -77,11 +78,13 @@ The following table lists configuration parameters in `values-edit.yaml`.
 
 ## Further Details
 
-This chart consists of two subcharts:
+This chart consists of two required subcharts and one optional subchart:
 
 * [Kubex Data Collector](../container-optimization-data-forwarder), which collects data and forwards it to a Kubex instance for analysis
 
 * [Prometheus Community Prometheus chart](https://github.com/prometheus-community/helm-charts/blob/main/charts/prometheus/) which contains the entire stack required for the Kubex Data Collector to collect data
+
+* [Node Labeler](../node-labeler), optional and disabled by default; set `node-labeler.enabled=true` to install
 
 ## Documentation
 

--- a/charts/kubex-automation-stack/values-edit.yaml
+++ b/charts/kubex-automation-stack/values-edit.yaml
@@ -35,3 +35,7 @@ container-optimization-data-forwarder:
   # server:
     # persistentVolume:
     #   storageClass: <changeme-storage-class>
+
+# Optional: Enable node-labeler subchart (disabled by default)
+# node-labeler:
+#   enabled: true

--- a/charts/kubex-automation-stack/values.yaml
+++ b/charts/kubex-automation-stack/values.yaml
@@ -7,6 +7,9 @@ stack:
   densify:
     createSecret: true
 
+node-labeler:
+  enabled: false
+
 container-optimization-data-forwarder:
   nameOverride: kubex-stack
   tolerations:

--- a/charts/kubex-collection-openshift/Chart.lock
+++ b/charts/kubex-collection-openshift/Chart.lock
@@ -5,5 +5,8 @@ dependencies:
 - name: k8s-ephemeral-storage-metrics
   repository: https://jmcgrath207.github.io/k8s-ephemeral-storage-metrics/chart
   version: 1.19.2
-digest: sha256:a1b8e2666a9f0f936ea60cfe3ff0342b44b12bfb8411a14470a44997c064be64
-generated: "2026-02-12T10:55:28.848052244Z"
+- name: node-labeler
+  repository: https://densify-dev.github.io/helm-charts
+  version: 0.1.0
+digest: sha256:0dae141d70a50e264ebab186ab1767c93cbe4f092b405f9784ff596fd00d45b8
+generated: "2026-02-19T15:19:31.107539556Z"

--- a/charts/kubex-collection-openshift/Chart.yaml
+++ b/charts/kubex-collection-openshift/Chart.yaml
@@ -12,6 +12,10 @@ dependencies:
     version: "1.*.*"
     repository: https://jmcgrath207.github.io/k8s-ephemeral-storage-metrics/chart
     condition: k8s-ephemeral-storage-metrics.enabled
+  - name: node-labeler
+    version: "0.1.0"
+    repository: https://densify-dev.github.io/helm-charts
+    condition: node-labeler.enabled
 keywords:
 - kubex
 - densify

--- a/charts/kubex-collection-openshift/Chart.yaml
+++ b/charts/kubex-collection-openshift/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 description: Kubex Collection Stack for OpenShift Clusters
 name: kubex-collection-openshift
-version: 1.0.5
+version: 1.0.6
 type: application
 icon: https://kubex.ai/wp-content/uploads/kubex-logo-landscape.svg
 dependencies:

--- a/charts/kubex-collection-openshift/README.md
+++ b/charts/kubex-collection-openshift/README.md
@@ -88,6 +88,7 @@ The following table lists configuration parameters in `values-edit.yaml`.
 | `container-optimization-data-forwarder.`<br/>`cronJob.ttlSecondsAfterFinished` |                    | TTL to keep jobs after completion/failure |
 | `container-optimization-data-forwarder.`<br/>`cronJob.backoffLimit` |                    | Backoff limit for jobs |
 | `k8s-ephemeral-storage-metrics.enabled`                                          |                    | Enable ephemeral storage metrics collection (default: `false`) |
+| `node-labeler.enabled`                                                           |                    | Enable optional node-labeler subchart (`false` by default) |
 
 ## Limitations
 
@@ -100,6 +101,7 @@ This chart consists of the following subcharts:
 
 * [Kubex Data Collector](../container-optimization-data-forwarder) - Collects data and forwards it to a Kubex instance for analysis
 * [k8s-ephemeral-storage-metrics](https://github.com/jmcgrath207/k8s-ephemeral-storage-metrics) - Collects ephemeral storage metrics for containers using CRI-O runtime
+* [Node Labeler](../node-labeler) - Optional and disabled by default; set `node-labeler.enabled=true` to install
 
 ## Documentation
 

--- a/charts/kubex-collection-openshift/values-edit.yaml
+++ b/charts/kubex-collection-openshift/values-edit.yaml
@@ -26,3 +26,7 @@ container-optimization-data-forwarder:
     # failedJobsHistoryLimit: <value>
     # ttlSecondsAfterFinished: <value> # applies for both the cronjob and the job
     # backoffLimit: <value> # applies for both the cronjob and the job, default: 4
+
+# Optional: Enable node-labeler subchart (disabled by default)
+# node-labeler:
+#   enabled: true

--- a/charts/kubex-collection-openshift/values.yaml
+++ b/charts/kubex-collection-openshift/values.yaml
@@ -2,6 +2,9 @@ stack:
   densify:
     createSecret: true
 
+node-labeler:
+  enabled: false
+
 container-optimization-data-forwarder:
   image: densify/container-optimization-data-forwarder:ubi10-4
   # required for OpenShift


### PR DESCRIPTION
Adds it both for kubex-automation-stack and kubex-collection-openshift