### PR TITLE
Remove unsupported containerSelector from automation engine chart

### DIFF
--- a/charts/kubex-automation-engine/Chart.yaml
+++ b/charts/kubex-automation-engine/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: kubex-automation-engine
 description: A Helm chart for deploying kubex-automation-engine for automated workload rightsizing and resource optimization
 type: application
-version: 0.1.2
+version: 0.1.3
 icon: https://www.kubex.ai/wp-content/uploads/kubex-by-densify-logo.png
 keywords:
   - kubex

--- a/charts/kubex-automation-engine/Chart.yaml
+++ b/charts/kubex-automation-engine/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: kubex-automation-engine
 description: A Helm chart for deploying kubex-automation-engine for automated workload rightsizing and resource optimization
 type: application
-version: 0.1.3
+version: 0.1.4
 icon: https://www.kubex.ai/wp-content/uploads/kubex-by-densify-logo.png
 keywords:
   - kubex

--- a/charts/kubex-automation-engine/docs/Cluster-Proactive-Policies.md
+++ b/charts/kubex-automation-engine/docs/Cluster-Proactive-Policies.md
@@ -18,8 +18,6 @@ For the namespaced variant, see [Proactive Policies](./Proactive-Policies.md). F
 | --- | --- | --- |
 | `spec.scope.labelSelector` | none | Kubernetes label selector for matching workloads. |
 | `spec.scope.workloadTypes` | `[Deployment, StatefulSet, CronJob, Rollout, Job, AnalysisRun, DaemonSet]` | Workload kinds this policy applies to. |
-| `spec.scope.containerSelector.field` | none | Container field to match. Only `Name` is supported. |
-| `spec.scope.containerSelector.patterns` | none | Shell-style `*` glob patterns for in-scope container names. |
 | `spec.scope.namespaceSelector.operator` | none | Namespace selector operator: `In` or `NotIn`. |
 | `spec.scope.namespaceSelector.values` | none | Namespace patterns to include or exclude. |
 | `spec.automationStrategyRef.name` | none | Required cluster strategy name. |
@@ -35,11 +33,6 @@ metadata:
   name: platform-prod-proactive
 spec:
   scope:
-    containerSelector:
-      field: Name
-      patterns:
-        - api*
-        - worker
     labelSelector:
       matchLabels:
         team: platform
@@ -68,6 +61,5 @@ spec:
 ## Notes
 
 - Use cluster proactive policies when a platform team needs one recommendation-driven policy across many namespaces.
-- `scope.containerSelector` filters Kubex recommendations after workload and namespace scope are resolved.
 - Start with narrow namespace and label selectors, then widen scope after verifying the selected-policy behavior in events and controller logs.
 - If you need per-namespace ownership instead, use namespaced `ProactivePolicy`.

--- a/charts/kubex-automation-engine/docs/Configuration-Reference.md
+++ b/charts/kubex-automation-engine/docs/Configuration-Reference.md
@@ -161,8 +161,6 @@ These values apply to Helm-managed recommendation-driven automation only. If you
 | `scope[].namespaces.operator` | `In` or `NotIn` |
 | `scope[].namespaces.values` | Namespace selection values |
 | `scope[].podLabels` | Label selector rules converted to `matchLabels` or `matchExpressions` |
-| `scope[].containerSelector.field` | Container field written to `ClusterProactivePolicy.spec.scope.containerSelector.field`; only `Name` is supported |
-| `scope[].containerSelector.patterns` | Container name glob patterns written to `ClusterProactivePolicy.spec.scope.containerSelector.patterns` |
 | `scope[].weight` | Policy weight for precedence resolution |
 
 For the generated resource fields behind these values, see [Cluster Automation Strategies](./Cluster-Automation-Strategies.md) and [Cluster Proactive Policies](./Cluster-Proactive-Policies.md).

--- a/charts/kubex-automation-engine/docs/Policy-Configuration.md
+++ b/charts/kubex-automation-engine/docs/Policy-Configuration.md
@@ -67,7 +67,6 @@ Those resources remain fully supported by the controller and can be managed outs
 | `scope[].policy` or `policy.defaultPolicy` | `ClusterProactivePolicy.spec.automationStrategyRef.name` | References the generated or externally managed `ClusterAutomationStrategy` with that name. |
 | `scope[].namespaces` | `ClusterProactivePolicy.spec.scope.namespaceSelector` | Namespace include or exclude rules. |
 | `scope[].podLabels` | `ClusterProactivePolicy.spec.scope.labelSelector` | Converted into `matchLabels` or `matchExpressions`. |
-| `scope[].containerSelector` | `ClusterProactivePolicy.spec.scope.containerSelector` | Narrows recommendation-driven automation to matching container names. |
 | `scope[].weight` | `ClusterProactivePolicy.spec.weight` | Higher weight wins within the same policy type. |
 | `policy.policies.<name>.allowedPodOwners` | `ClusterProactivePolicy.spec.scope.workloadTypes` | Supported values: `Deployment`, `StatefulSet`, `DaemonSet`, `CronJob`, `Rollout`, `Job`, `AnalysisRun`. |
 | `policy.policies.<name>.safetyChecks.maxAnalysisAgeDays` | `ClusterProactivePolicy.spec.safetyChecks.maxAnalysisAgeDays` | Per-policy value wins over top-level `policy.safetyChecks.maxAnalysisAgeDays`. |

--- a/charts/kubex-automation-engine/docs/Proactive-Policies.md
+++ b/charts/kubex-automation-engine/docs/Proactive-Policies.md
@@ -20,8 +20,6 @@ For the cluster-scoped variant, see [Cluster Proactive Policies](./Cluster-Proac
 | `spec.scope` | none | Optional scope object for workload selection. |
 | `spec.scope.labelSelector` | none | Kubernetes label selector for matching workloads. |
 | `spec.scope.workloadTypes` | `[Deployment, StatefulSet, CronJob, Rollout, Job, AnalysisRun, DaemonSet]` | Workload kinds this policy applies to. |
-| `spec.scope.containerSelector.field` | none | Container field to match. Only `Name` is supported. |
-| `spec.scope.containerSelector.patterns` | none | Shell-style `*` glob patterns for in-scope container names. |
 | `spec.automationStrategyRef.name` | none | Required namespaced strategy name. |
 | `spec.weight` | `0` | Higher weight wins when multiple proactive policies match. |
 | `spec.safetyChecks.maxAnalysisAgeDays` | `5` | Rejects old recommendations. |
@@ -36,11 +34,6 @@ metadata:
   namespace: team-a
 spec:
   scope:
-    containerSelector:
-      field: Name
-      patterns:
-        - api*
-        - worker
     labelSelector:
       matchLabels:
         app.kubernetes.io/part-of: storefront
@@ -63,6 +56,5 @@ spec:
 ## Notes
 
 - Use namespaced proactive policies when teams own their own namespaces.
-- `scope.containerSelector` filters Kubex recommendations to matching containers after the workload itself is selected.
 - When multiple proactive policies of the same kind match, higher `weight` wins, then older objects win on ties.
 - For cluster-scoped examples and field references, see [Cluster Proactive Policies](./Cluster-Proactive-Policies.md).

--- a/charts/kubex-automation-engine/docs/Static-Policies.md
+++ b/charts/kubex-automation-engine/docs/Static-Policies.md
@@ -18,8 +18,6 @@ Use them when you want deterministic resource values instead of recommendation-d
 | `spec.scope` | none | Optional scope object for workload selection in the same namespace. |
 | `spec.scope.labelSelector` | none | Kubernetes label selector for matching workloads. |
 | `spec.scope.workloadTypes` | `[Deployment, StatefulSet, CronJob, Rollout, Job, AnalysisRun, DaemonSet]` | Workload kinds this policy applies to. |
-| `spec.scope.containerSelector.field` | none | Container field to match. Only `Name` is supported. |
-| `spec.scope.containerSelector.patterns` | none | Shell-style `*` glob patterns for in-scope container names. |
 | `spec.resources.containers` | none | Map of container names to requests and limits. Use `"*"` for all containers. |
 | `spec.weight` | `0` | Higher weight wins when multiple static policies match. |
 | `spec.automationStrategyRef.name` | none | Required namespaced strategy name. |
@@ -30,8 +28,6 @@ Use them when you want deterministic resource values instead of recommendation-d
 | --- | --- | --- |
 | `spec.scope.labelSelector` | none | Kubernetes label selector for matching workloads. |
 | `spec.scope.workloadTypes` | `[Deployment, StatefulSet, CronJob, Rollout, Job, AnalysisRun, DaemonSet]` | Workload kinds this policy applies to. |
-| `spec.scope.containerSelector.field` | none | Container field to match. Only `Name` is supported. |
-| `spec.scope.containerSelector.patterns` | none | Shell-style `*` glob patterns for in-scope container names. |
 | `spec.scope.namespaceSelector.operator` | none | Namespace selector operator: `In` or `NotIn`. |
 | `spec.scope.namespaceSelector.values` | none | Namespace patterns to include or exclude. |
 | `spec.resources.containers` | none | Map of container names to requests and limits. Use `"*"` for all containers. |
@@ -48,11 +44,6 @@ metadata:
   namespace: team-a
 spec:
   scope:
-    containerSelector:
-      field: Name
-      patterns:
-        - api*
-        - worker
     labelSelector:
       matchLabels:
         app.kubernetes.io/part-of: storefront
@@ -95,11 +86,6 @@ metadata:
   name: platform-database-baseline
 spec:
   scope:
-    containerSelector:
-      field: Name
-      patterns:
-        - postgres
-        - metrics
     labelSelector:
       matchLabels:
         tier: database
@@ -135,5 +121,4 @@ spec:
 
 - Use static policies when exact values matter more than recommendation-driven tuning.
 - `resources.containers."*"` applies a default to every container, and named containers can override it.
-- When `scope.containerSelector` is set, only matching containers receive static resources; wildcard `resources.containers."*"` is expanded only across those matching container names.
 - When multiple static policies of the same kind match, higher `weight` wins, then older objects win on ties.

--- a/charts/kubex-automation-engine/templates/clusterproactivepolicy.yaml
+++ b/charts/kubex-automation-engine/templates/clusterproactivepolicy.yaml
@@ -55,14 +55,6 @@ spec:
       - {{ . | trim }}
       {{- end }}
     {{- end }}
-    {{- with $scopeConfig.containerSelector }}
-    containerSelector:
-      field: {{ .field | quote }}
-      patterns:
-        {{- range .patterns }}
-        - {{ . | quote }}
-        {{- end }}
-    {{- end }}
   automationStrategyRef:
     name: {{ $policyName }}
   {{- /* Resolve maxAnalysisAgeDays: per-policy config (new) takes precedence over top-level policy (old) */}}

--- a/charts/kubex-automation-engine/values.schema.json
+++ b/charts/kubex-automation-engine/values.schema.json
@@ -160,22 +160,6 @@
             "items": {
               "type": "object"
             }
-          },
-          "containerSelector": {
-            "type": "object",
-            "properties": {
-              "field": {
-                "type": "string"
-              },
-              "patterns": {
-                "type": "array",
-                "items": {
-                  "type": "string",
-                  "minLength": 1
-                },
-                "minItems": 1
-              }
-            }
           }
         }
       }

--- a/charts/kubex-automation-engine/values.yaml
+++ b/charts/kubex-automation-engine/values.yaml
@@ -4,7 +4,7 @@ crdCheck:
   skip: false
   # Minimum version of the kubex-crds chart required before this chart can be installed/upgraded.
   # Bump this whenever a new CRD field or schema change is required.
-  minCRDsHelmVersion: "0.1.0"
+  minCRDsHelmVersion: "0.1.1"
 # -- Whether to create the kubex-gateway-config Secret automatically
 createSecrets: true
 
@@ -44,7 +44,7 @@ image:
   # -- Image pull policy
   pullPolicy: IfNotPresent
   # -- Image tag
-  tag: "0.1.2"
+  tag: "0.1.3"
 
 cleanup:
   image:

--- a/charts/kubex-automation-engine/values.yaml
+++ b/charts/kubex-automation-engine/values.yaml
@@ -359,12 +359,6 @@ scope: []
   #     #   values:
   #     #     - development
   #     #     - staging
-  #   containerSelector:               # Optional - narrows matching containers within the selected workloads
-  #     field: Name                    # Currently only Name is supported
-  #     patterns:
-  #       - api*
-  #       - worker
-
 # ================================================================
 # SECTION: AUTOMATION POLICY - Define HOW automation behaves
 # Instructions:

--- a/charts/kubex-crds/Chart.yaml
+++ b/charts/kubex-crds/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: kubex-crds
 description: CRDs for Kubex Automation Engine early access releases
-version: 0.1.0
+version: 0.1.1
 appVersion: v0.1
 keywords:
   - crd


### PR DESCRIPTION
## Summary
- remove unsupported `scope[].containerSelector` handling from the automation engine chart, schema, sample values, and docs
- bump the chart version to 0.1.4 for the patch release

## Validation
```bash
helm template review charts/kubex-automation-engine \
  --set crdCheck.skip=true \
  --set kubex.url.host=example \
  --set kubexCredentials.username=u \
  --set kubexCredentials.epassword=p \
  --set policy.policies.default.enablement.cpu.requests.floor=100m \
  --set policy.policies.default.enablement.cpu.requests.containers.api.floor=200m \
  --set scope[0].name=scope1 \
  --set scope[0].policy=default \
  --set scope[0].namespaces.operator=In \
  --set scope[0].namespaces.values[0]=team-a | rg -n "containerSelector"
```
Command output: `rg exit 1` (return code 1 means `rg` found no matches, so the field is absent in the rendered templates).

```bash
helm template review charts/kubex-automation-engine \
  --set crdCheck.skip=true \
  --set kubex.url.host=example \
  --set kubexCredentials.username=u \
  --set kubexCredentials.epassword=p \
  --set policy.policies.default.enablement.cpu.requests.floor=100m \
  --set policy.policies.default.enablement.cpu.requests.containers.api.floor=200m \
  --set scope[0].name=scope1 \
  --set scope[0].policy=default \
  --set scope[0].namespaces.operator=In \
  --set scope[0].namespaces.values[0]=team-a \
  --set scope[0].containerSelector.field=Name \
  --set scope[0].containerSelector.patterns[0]=api* | rg -n "containerSelector"
```
Command output: `rg exit 1` (still no matches despite supplying the removed value).