### PR TITLE
Honor webhook.enabled more consistently

### DIFF
--- a/charts/kubex-automation-engine/templates/mutatingwebhook.yaml
+++ b/charts/kubex-automation-engine/templates/mutatingwebhook.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.webhook.enabled -}}
 {{- if not .Values.webhook.certManager.enabled -}}
 {{- $_ := include "kubex-automation-engine.gen-certs-data" . -}}
 {{- end }}
@@ -34,3 +35,4 @@ webhooks:
     resources:
     - pods
   sideEffects: None
+{{- end }}

--- a/charts/kubex-automation-engine/templates/validatingwebhook.yaml
+++ b/charts/kubex-automation-engine/templates/validatingwebhook.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.webhook.enabled -}}
 {{- if not .Values.webhook.certManager.enabled -}}
 {{- $_ := include "kubex-automation-engine.gen-certs-data" . -}}
 {{- end }}
@@ -175,3 +176,4 @@ webhooks:
     resources:
     - staticpolicies
   sideEffects: None
+{{- end }}

--- a/charts/kubex-automation-engine/templates/webhook-service.yaml
+++ b/charts/kubex-automation-engine/templates/webhook-service.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.webhook.enabled -}}
 apiVersion: v1
 kind: Service
 metadata:
@@ -14,3 +15,4 @@ spec:
     targetPort: webhook
   selector:
     {{- include "kubex-automation-engine.selectorLabels" . | nindent 4 }}
+{{- end }}


### PR DESCRIPTION
This comes as a result of creating kubebuilder sync tooling to helm charts and it found that this was not honored properly