### PR TITLE
chore: update helm lock with new chart version

### DIFF
--- a/charts/kubex-automation-stack/Chart.lock
+++ b/charts/kubex-automation-stack/Chart.lock
@@ -1,7 +1,7 @@
 dependencies:
 - name: container-optimization-data-forwarder
   repository: https://densify-dev.github.io/helm-charts
-  version: 4.0.14
+  version: 4.0.15
 - name: prometheus
   repository: https://prometheus-community.github.io/helm-charts
   version: 27.52.0
@@ -11,5 +11,5 @@ dependencies:
 - name: node-labeler
   repository: https://densify-dev.github.io/helm-charts
   version: 0.1.0
-digest: sha256:75be31895649657a021cb8be85fd4d01d8c8892b89760d8f93f03dbf21bc3c33
-generated: "2026-04-16T19:11:11.201222544Z"
+digest: sha256:e949b09490282bd75515627c787bbd26c5c03b5fafe707fc992acb9d689b78b1
+generated: "2026-04-17T15:32:59.961670817-04:00"

--- a/charts/kubex-automation-stack/Chart.yaml
+++ b/charts/kubex-automation-stack/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 description: Kubex Collection Stack
 name: kubex-automation-stack
-version: 1.0.7
+version: 1.0.8
 type: application
 icon: https://www.kubex.ai/wp-content/uploads/kubex-by-densify-logo.png
 dependencies:


### PR DESCRIPTION
Updates `data-forwarder` chart version to use new charts with split image repository and tag values