### PR TITLE
feat(chart): restore automation stack changes

### DIFF
--- a/charts/container-optimization-data-forwarder/templates/configmap.yaml
+++ b/charts/container-optimization-data-forwarder/templates/configmap.yaml
@@ -8,12 +8,15 @@ metadata:
     chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
+{{- $densifyUrl := .Values.config.forwarder.densify.url | required ".Values.config.forwarder.densify.url is required." }}
+{{- $densifyHost := $densifyUrl.host | required ".Values.config.forwarder.densify.url.host is required." }}
 data:
+  kubex_host: {{ $densifyHost | quote }}
+  kubex_tenant_id: {{ index (splitList "." $densifyHost) 0 | quote }}
+  kubex_cluster_name: {{ (first .Values.config.clusters).name | quote }}
   config.yaml : |
     forwarder:
       densify:
-{{- $densifyUrl := .Values.config.forwarder.densify.url | required ".Values.config.forwarder.densify.url is required." }}
-{{- $densifyHost := $densifyUrl.host | required ".Values.config.forwarder.densify.url.host is required." }}
         url: {{- omit $densifyUrl "UserSecretName" | toYaml | trim | nindent 10 }}
 {{- if .Values.config.forwarder.densify.endpoint }}
         endpoint: {{ .Values.config.forwarder.densify.endpoint }}

--- a/charts/kubex-automation-stack/CHANGELOG.md
+++ b/charts/kubex-automation-stack/CHANGELOG.md
@@ -2,6 +2,20 @@
 
 All notable changes to the kubex-automation-stack chart will be documented in this file.
 
+## [1.0.19] - 2026-07-03
+
+### Added
+- Added optional `kubex-connector` and `kubex-ai-cdi` subchart support to the stack
+- Added stack-managed CDI service account, ClusterRole, and ClusterRoleBinding templates
+- Added forwarder `ConfigMap` keys for shared Kubex host, tenant, and cluster name consumption
+
+### Changed
+- Switched stack-managed connector tunnel wiring to `/tunnel/connect`
+- Documented stack-managed connector/CDI configuration and RBAC behavior
+
+### Fixed
+- Disabled the forwarder hook job in the OpenShift overlay so the cron-based collector path is used consistently
+- Added OpenShift security context defaults for stack-managed connector and CDI deployments
 
 ## [1.0.17] - 2026-06-23
 

--- a/charts/kubex-automation-stack/Chart.lock
+++ b/charts/kubex-automation-stack/Chart.lock
@@ -2,6 +2,12 @@ dependencies:
 - name: container-optimization-data-forwarder
   repository: https://densify-dev.github.io/helm-charts
   version: 4.0.17
+- name: kubex-connector
+  repository: https://densify-dev.github.io/helm-charts
+  version: 0.1.7
+- name: kubex-ai-cdi
+  repository: https://densify-dev.github.io/helm-charts
+  version: 0.1.7
 - name: prometheus
   repository: https://prometheus-community.github.io/helm-charts
   version: 29.13.0
@@ -17,5 +23,5 @@ dependencies:
 - name: node-labeler
   repository: https://densify-dev.github.io/helm-charts
   version: 0.1.2
-digest: sha256:c498ce4d74c71ae798389273aa7a982b7b5bab36fda22cf138ce8d9fc7df4d91
-generated: "2026-06-23T13:15:52.035420594-04:00"
+digest: sha256:236fb101181ec35633ff5b63d691d7a2d812db1c1e12bdc6aef31b53802bcb81
+generated: "2026-06-18T17:22:19.699220044-04:00"

--- a/charts/kubex-automation-stack/Chart.lock
+++ b/charts/kubex-automation-stack/Chart.lock
@@ -23,6 +23,5 @@ dependencies:
 - name: node-labeler
   repository: https://densify-dev.github.io/helm-charts
   version: 0.1.2
-<<<<<<< HEAD
 digest: sha256:d4b36dc243779019f4a3277b17c487f1be80c39d5a6ce5a3b40979a42dbc5955
 generated: "2026-07-03T17:48:40.199770372Z"

--- a/charts/kubex-automation-stack/Chart.yaml
+++ b/charts/kubex-automation-stack/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 description: Kubex Collection Stack
 name: kubex-automation-stack
-version: 1.0.18
+version: 1.0.19
 type: application
 icon: https://kubex.ai/wp-content/uploads/kubex-logo-landscape.svg
 dependencies:

--- a/charts/kubex-automation-stack/Chart.yaml
+++ b/charts/kubex-automation-stack/Chart.yaml
@@ -1,13 +1,21 @@
 apiVersion: v2
 description: Kubex Collection Stack
 name: kubex-automation-stack
-version: 1.0.17
+version: 1.0.18
 type: application
 icon: https://kubex.ai/wp-content/uploads/kubex-logo-landscape.svg
 dependencies:
   - name: container-optimization-data-forwarder
     version: "4.*.*"
     repository: https://densify-dev.github.io/helm-charts
+  - name: kubex-connector
+    version: "0.1.*"
+    repository: https://densify-dev.github.io/helm-charts
+    condition: kubex-connector.enabled
+  - name: kubex-ai-cdi
+    version: "0.1.*"
+    repository: https://densify-dev.github.io/helm-charts
+    condition: kubex-ai-cdi.enabled
   - name: prometheus
     version: "29.*.*"
     repository: https://prometheus-community.github.io/helm-charts

--- a/charts/kubex-automation-stack/README.md
+++ b/charts/kubex-automation-stack/README.md
@@ -114,7 +114,6 @@ The following table lists configuration parameters in `values-edit.yaml`.
 | `gpu-process-exporter.enabled`                                                           |                    | Enable GPU process exporter subchart (default: `true`) |
 | `beyla.enabled`                                                           |                    | Enable Grafana Beyla for application runtime detection (default: `true`) |
 | `k8s-ephemeral-storage-metrics.enabled`                                          |                    | Enable ephemeral storage metrics collection (default: `true`) |
-| `node-labeler.enabled`                                                           |                    | Enable optional node-labeler subchart (default: `false`) |
 | `kubex-connector.enabled`                                                        |                    | Enable optional connector subchart (default: `false`) |
 | `kubex-ai-cdi.enabled`                                                           |                    | Enable optional kubex-ai-cdi subchart (default: `false`) |
 | `kubex-connector.heartbeatSeconds`                                               |                    | Connector heartbeat interval in seconds |
@@ -149,7 +148,7 @@ This chart consists of the following subcharts:
   - Additional Kubex-specific grouping labels are needed beyond cloud provider labels
   - Enhanced node group visibility is desired in OpenShift environments (leverages Machine API)
 
-* [Kubex Connector](../kubex-ai-connector) - Optional in-cluster connector used for the cluster data interface.
+* [Kubex Connector](../kubex-connector) - Optional in-cluster connector used for the cluster data interface.
 
 * [kubex-ai-cdi](../kubex-ai-cdi) - Optional in-cluster Kubex cluster data interface service.
 

--- a/charts/kubex-automation-stack/README.md
+++ b/charts/kubex-automation-stack/README.md
@@ -114,6 +114,7 @@ The following table lists configuration parameters in `values-edit.yaml`.
 | `gpu-process-exporter.enabled`                                                           |                    | Enable GPU process exporter subchart (default: `true`) |
 | `beyla.enabled`                                                           |                    | Enable Grafana Beyla for application runtime detection (default: `true`) |
 | `k8s-ephemeral-storage-metrics.enabled`                                          |                    | Enable ephemeral storage metrics collection (default: `true`) |
+| `node-labeler.enabled`                                                           |                    | Enable optional node-labeler subchart to add Kubex Node Group labels to nodes; useful when nodes lack standard cloud provider node pool/group labels (default: `false`) |
 | `kubex-connector.enabled`                                                        |                    | Enable optional connector subchart (default: `false`) |
 | `kubex-ai-cdi.enabled`                                                           |                    | Enable optional kubex-ai-cdi subchart (default: `false`) |
 | `kubex-connector.heartbeatSeconds`                                               |                    | Connector heartbeat interval in seconds |
@@ -122,7 +123,8 @@ The following table lists configuration parameters in `values-edit.yaml`.
 Connector and CDI use the shared Kubex host and cluster entered under `container-optimization-data-forwarder.config.*`. The forwarder publishes those runtime values in its `ConfigMap`, and the connector consumes them through `forwarderConfigMap.name`. Credentials come from `stack.densify` through `densify-api-secret`, which the connector consumes through `forwarderCredentialsSecretRef.name` by default. The stack chart also owns the CDI service account and RBAC by rendering those manifests itself while disabling `kubex-ai-cdi.rbac.enabled` in the subchart.
 
 For the full stack RBAC shape and defaults, refer to `charts/kubex-automation-stack/values.yaml`.
-| `node-labeler.enabled`                                                           |                    | Enable optional node-labeler subchart to add Kubex Node Group labels to nodes; useful when nodes lack standard cloud provider pool/group labels (default: `false`) |
+
+For a guided explanation of the stack-managed CDI RBAC model, see [docs/RBAC-Guide.md](docs/RBAC-Guide.md).
 
 ## Limitations
 

--- a/charts/kubex-automation-stack/README.md
+++ b/charts/kubex-automation-stack/README.md
@@ -115,6 +115,14 @@ The following table lists configuration parameters in `values-edit.yaml`.
 | `beyla.enabled`                                                           |                    | Enable Grafana Beyla for application runtime detection (default: `true`) |
 | `k8s-ephemeral-storage-metrics.enabled`                                          |                    | Enable ephemeral storage metrics collection (default: `true`) |
 | `node-labeler.enabled`                                                           |                    | Enable optional node-labeler subchart (default: `false`) |
+| `kubex-connector.enabled`                                                        |                    | Enable optional connector subchart (default: `false`) |
+| `kubex-ai-cdi.enabled`                                                           |                    | Enable optional kubex-ai-cdi subchart (default: `false`) |
+| `kubex-connector.heartbeatSeconds`                                               |                    | Connector heartbeat interval in seconds |
+| `kubex-connector.requestTimeoutSeconds`                                          |                    | Connector request timeout in seconds |
+
+Connector and CDI use the shared Kubex host and cluster entered under `container-optimization-data-forwarder.config.*`. The forwarder publishes those runtime values in its `ConfigMap`, and the connector consumes them through `forwarderConfigMap.name`. Credentials come from `stack.densify` through `densify-api-secret`, which the connector consumes through `forwarderCredentialsSecretRef.name` by default. The stack chart also owns the CDI service account and RBAC by rendering those manifests itself while disabling `kubex-ai-cdi.rbac.enabled` in the subchart.
+
+For the full stack RBAC shape and defaults, refer to `charts/kubex-automation-stack/values.yaml`.
 
 ## Limitations
 
@@ -136,6 +144,10 @@ This chart consists of the following subcharts:
 * [k8s-ephemeral-storage-metrics](../k8s-ephemeral-storage-metrics) - Collects ephemeral storage metrics for containers.
 
 * [Node Labeler](../node-labeler) - Adds labels to nodes to indicate which Kubex Node Group they belong to. This is an optional component that can be enabled if desired (disabled by default).
+
+* [Kubex Connector](../kubex-ai-connector) - Optional in-cluster connector used for the cluster data interface.
+
+* [kubex-ai-cdi](../kubex-ai-cdi) - Optional in-cluster Kubex cluster data interface service.
 
 ## Documentation
 

--- a/charts/kubex-automation-stack/docs/RBAC-Guide.md
+++ b/charts/kubex-automation-stack/docs/RBAC-Guide.md
@@ -1,0 +1,78 @@
+# RBAC Guide
+
+This guide explains the RBAC model used by `kubex-automation-stack` for the optional connector and CDI components.
+
+## Overview
+
+When `kubex-connector.enabled=true` and `kubex-ai-cdi.enabled=true`, the stack deploys:
+
+- the in-cluster connector used for tunnel-based access
+- the in-cluster CDI service used to expose cluster data
+- stack-managed CDI RBAC resources
+
+The stack keeps CDI RBAC ownership at the umbrella chart layer and disables subchart RBAC with `kubex-ai-cdi.rbac.enabled=false`.
+
+## CDI RBAC Ownership
+
+The stack renders these resources directly:
+
+- `ServiceAccount/kubex-ai-cdi-sa`
+- `ClusterRole/kubex-ai-cdi-reader`
+- `ClusterRoleBinding/kubex-ai-cdi-reader`
+
+Those resources are controlled through `rbac.permissions.cdi.*` in `values.yaml`.
+
+## Default CDI Permissions
+
+By default, the stack grants CDI read access to the cluster resources needed for cluster data interface behavior, including:
+
+- core resources: `pods`, `services`, `configmaps`, `namespaces`, `nodes`, `events`
+- pod logs: `pods/log`
+- workloads: `deployments`, `daemonsets`, `statefulsets`, `replicasets`
+- rollout APIs: `rollouts`, `analysisruns`, `experiments`
+- Kubex rightsizing CRDs
+- self-subject review APIs for capability discovery
+
+The default rule set also includes optional integrations for:
+
+- OpenShift Machine API resources when `openshift.enabled=true`
+- Karpenter resources
+- Karpenter AWS node class resources
+
+## Connector RBAC
+
+The connector itself does not create RBAC resources in the stack. It consumes runtime identity from the forwarder `ConfigMap` and credentials from `densify-api-secret` through `forwarderCredentialsSecretRef`.
+
+The stack leaves `rbac.permissions.connector.*` disabled by default because the connector currently does not require additional Kubernetes API permissions for its tunnel role.
+
+## Runtime Wiring
+
+The stack-managed connector and CDI share cluster identity from the forwarder-generated `ConfigMap`:
+
+- `kubex_host`
+- `kubex_tenant_id`
+- `kubex_cluster_name`
+
+The connector uses those values to derive:
+
+- `CONNECTOR_PROXY_WS_URL`
+- `CONNECTOR_TENANT_ID`
+- `CONNECTOR_CLUSTER_ID`
+- `RELAY_UPSTREAM_WSS_URL`
+- `DENSIFY_BASE_URL`
+
+## Validation
+
+Useful checks after install:
+
+```bash
+kubectl -n kubex get serviceaccount kubex-ai-cdi-sa
+kubectl get clusterrole kubex-ai-cdi-reader
+kubectl get clusterrolebinding kubex-ai-cdi-reader
+kubectl auth can-i --list --as=system:serviceaccount:kubex:kubex-ai-cdi-sa
+kubectl -n kubex get configmap kubex-kubex-stack -o yaml
+```
+
+## OpenShift Note
+
+For OpenShift installs, use `values-openshift.yaml` so the stack-managed connector and CDI receive compatible security context defaults.

--- a/charts/kubex-automation-stack/templates/_helpers.tpl
+++ b/charts/kubex-automation-stack/templates/_helpers.tpl
@@ -1,6 +1,19 @@
 {{- define "common.namespace" -}}
   {{- default .Release.Namespace .Values.nsPrefix -}}
 {{- end -}}
+{{- define "common.kubexHost" -}}
+{{- $forwarder := index .Values "container-optimization-data-forwarder" | default dict -}}
+{{- $config := $forwarder.config | default dict -}}
+{{- $densify := $config.forwarder.densify | default dict -}}
+{{- $url := $densify.url | default dict -}}
+{{- trim (default "" $url.host) -}}
+{{- end -}}
+{{- define "common.kubexClusters" -}}
+{{- $forwarder := index .Values "container-optimization-data-forwarder" | default dict -}}
+{{- $config := $forwarder.config | default dict -}}
+{{- $clusters := $config.clusters | default list -}}
+{{- toYaml $clusters -}}
+{{- end -}}
 {{- define "common.checkValues" -}}
 {{- $openshiftEnabled := .Values.openshift.enabled -}}
 {{- $deployPrometheus := .Values.stack.prometheus.deploy -}}

--- a/charts/kubex-automation-stack/templates/kubex-ai-cdi-clusterrole.yaml
+++ b/charts/kubex-automation-stack/templates/kubex-ai-cdi-clusterrole.yaml
@@ -1,0 +1,111 @@
+{{- $rbac := .Values.rbac | default dict -}}
+{{- $cdi := $rbac.permissions.cdi | default dict -}}
+{{- $rules := $cdi.rules | default dict -}}
+{{- $clusterRole := $cdi.clusterRole | default dict -}}
+{{- $cdiValues := index .Values "kubex-ai-cdi" | default dict -}}
+{{- $cdiRbac := $cdiValues.rbac | default dict -}}
+{{- $extraLabels := $cdiValues.extraLabels | default dict -}}
+{{- $extraAnnotations := $cdiValues.extraAnnotations | default dict -}}
+{{- if and $cdiValues.enabled $rbac.create (not ($cdiRbac.enabled | default false)) (dig "create" false $clusterRole) }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ default "kubex-ai-cdi-reader" (dig "name" "" $clusterRole) }}
+  labels:
+    app: kubex-ai-cdi
+    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+    {{- if $extraLabels }}
+    {{- toYaml $extraLabels | nindent 4 }}
+    {{- end }}
+  {{- if $extraAnnotations }}
+  annotations:
+    {{- toYaml $extraAnnotations | nindent 4 }}
+  {{- end }}
+rules:
+{{- with $rules.core }}
+{{- if .enabled }}
+- apiGroups: [""]
+  resources:
+    {{- toYaml (.resources | default (list)) | nindent 4 }}
+  verbs:
+    {{- toYaml (.verbs | default (list)) | nindent 4 }}
+{{- end }}
+{{- end }}
+{{- with $rules.podLogs }}
+{{- if .enabled }}
+- apiGroups: [""]
+  resources:
+    {{- toYaml (.resources | default (list)) | nindent 4 }}
+  verbs:
+    {{- toYaml (.verbs | default (list)) | nindent 4 }}
+{{- end }}
+{{- end }}
+{{- with $rules.workloads }}
+{{- if .enabled }}
+- apiGroups: ["apps"]
+  resources:
+    {{- toYaml (.resources | default (list)) | nindent 4 }}
+  verbs:
+    {{- toYaml (.verbs | default (list)) | nindent 4 }}
+{{- end }}
+{{- end }}
+{{- with $rules.rollouts }}
+{{- if .enabled }}
+- apiGroups: ["argoproj.io"]
+  resources:
+    {{- toYaml (.resources | default (list)) | nindent 4 }}
+  verbs:
+    {{- toYaml (.verbs | default (list)) | nindent 4 }}
+{{- end }}
+{{- end }}
+{{- $openshiftRule := $rules.openshift | default dict -}}
+{{- $openshiftEnabled := dig "enabled" nil $openshiftRule -}}
+{{- if eq $openshiftEnabled nil -}}
+{{- $openshiftEnabled = .Values.openshift.enabled -}}
+{{- end -}}
+{{- if $openshiftEnabled }}
+- apiGroups: ["machine.openshift.io"]
+  resources:
+    {{- toYaml ((dig "resources" (list) $openshiftRule)) | nindent 4 }}
+  verbs:
+    {{- toYaml ((dig "verbs" (list) $openshiftRule)) | nindent 4 }}
+{{- end }}
+{{- with $rules.karpenter }}
+{{- if .enabled }}
+- apiGroups: ["karpenter.sh"]
+  resources:
+    {{- toYaml (.resources | default (list)) | nindent 4 }}
+  verbs:
+    {{- toYaml (.verbs | default (list)) | nindent 4 }}
+{{- end }}
+{{- end }}
+{{- with $rules.karpenterAWS }}
+{{- if .enabled }}
+- apiGroups: ["karpenter.k8s.aws"]
+  resources:
+    {{- toYaml (.resources | default (list)) | nindent 4 }}
+  verbs:
+    {{- toYaml (.verbs | default (list)) | nindent 4 }}
+{{- end }}
+{{- end }}
+{{- with $rules.kubexCRDs }}
+{{- if .enabled }}
+- apiGroups: ["rightsizing.kubex.ai"]
+  resources:
+    {{- toYaml (.resources | default (list)) | nindent 4 }}
+  verbs:
+    {{- toYaml (.verbs | default (list)) | nindent 4 }}
+{{- end }}
+{{- end }}
+{{- with $rules.selfSubjectReview }}
+{{- if .enabled }}
+- apiGroups: ["authorization.k8s.io"]
+  resources:
+    {{- toYaml (.resources | default (list)) | nindent 4 }}
+  verbs:
+    {{- toYaml (.verbs | default (list)) | nindent 4 }}
+{{- end }}
+{{- end }}
+{{- end }}

--- a/charts/kubex-automation-stack/templates/kubex-ai-cdi-clusterrolebinding.yaml
+++ b/charts/kubex-automation-stack/templates/kubex-ai-cdi-clusterrolebinding.yaml
@@ -1,0 +1,34 @@
+{{- $rbac := .Values.rbac | default dict -}}
+{{- $cdi := $rbac.permissions.cdi | default dict -}}
+{{- $clusterRole := $cdi.clusterRole | default dict -}}
+{{- $serviceAccount := $cdi.serviceAccount | default dict -}}
+{{- $cdiValues := index .Values "kubex-ai-cdi" | default dict -}}
+{{- $cdiRbac := $cdiValues.rbac | default dict -}}
+{{- $extraLabels := $cdiValues.extraLabels | default dict -}}
+{{- $extraAnnotations := $cdiValues.extraAnnotations | default dict -}}
+{{- if and $cdiValues.enabled $rbac.create (not ($cdiRbac.enabled | default false)) (dig "create" false $clusterRole) }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ default "kubex-ai-cdi-reader" (dig "name" "" $clusterRole) }}
+  labels:
+    app: kubex-ai-cdi
+    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+    {{- if $extraLabels }}
+    {{- toYaml $extraLabels | nindent 4 }}
+    {{- end }}
+  {{- if $extraAnnotations }}
+  annotations:
+    {{- toYaml $extraAnnotations | nindent 4 }}
+  {{- end }}
+subjects:
+- kind: ServiceAccount
+  name: {{ default "kubex-ai-cdi-sa" (dig "name" "" $serviceAccount) }}
+  namespace: {{ template "common.namespace" . }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ default "kubex-ai-cdi-reader" (dig "name" "" $clusterRole) }}
+{{- end }}

--- a/charts/kubex-automation-stack/templates/kubex-ai-cdi-serviceaccount.yaml
+++ b/charts/kubex-automation-stack/templates/kubex-ai-cdi-serviceaccount.yaml
@@ -1,0 +1,26 @@
+{{- $rbac := .Values.rbac | default dict -}}
+{{- $cdi := $rbac.permissions.cdi | default dict -}}
+{{- $serviceAccount := $cdi.serviceAccount | default dict -}}
+{{- $cdiValues := index .Values "kubex-ai-cdi" | default dict -}}
+{{- $cdiRbac := $cdiValues.rbac | default dict -}}
+{{- $extraLabels := $cdiValues.extraLabels | default dict -}}
+{{- $extraAnnotations := $cdiValues.extraAnnotations | default dict -}}
+{{- if and $cdiValues.enabled $rbac.create (not ($cdiRbac.enabled | default false)) (dig "create" false $serviceAccount) }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ default "kubex-ai-cdi-sa" (dig "name" "" $serviceAccount) }}
+  namespace: {{ template "common.namespace" . }}
+  labels:
+    app: kubex-ai-cdi
+    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+    {{- if $extraLabels }}
+    {{- toYaml $extraLabels | nindent 4 }}
+    {{- end }}
+  {{- if $extraAnnotations }}
+  annotations:
+    {{- toYaml $extraAnnotations | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/charts/kubex-automation-stack/values-edit.yaml
+++ b/charts/kubex-automation-stack/values-edit.yaml
@@ -17,12 +17,20 @@ container-optimization-data-forwarder:
     clusters:
       - name: '<changeme-cluster-name>' # mandatory
 
-  # Optional: Additional labels to add to CronJob and Job resources
-  #extraLabels:
-  #  my-custom-label: my-value-1
-  # Optional: Additional annotations to add to CronJob and Job resources
-  #extraAnnotations:
-  #  my-custom-annotation: my-value-2
+# Optional: Enable the connector and CDI tunnel path.
+# Keep these opt-in until the feature is generally available in production.
+# kubex-connector:
+#   enabled: true
+#
+# kubex-ai-cdi:
+#   enabled: true
+
+#   Optional: Additional labels inherited by CDI resources
+#   extraLabels:
+#     my-custom-label: my-value-1
+#   Optional: Additional annotations inherited by CDI resources
+#   extraAnnotations:
+#     my-custom-annotation: my-value-2
 
 # The following values are optional, if job cleanup is required;
 # each one of these should be a non-negative integer (0 is allowed)

--- a/charts/kubex-automation-stack/values-openshift.yaml
+++ b/charts/kubex-automation-stack/values-openshift.yaml
@@ -8,6 +8,7 @@ stack:
 container-optimization-data-forwarder:
   assignedUIDs: true
   job:
+    enable: false
     checkPrometheusReady: false
   config:
     prometheus:
@@ -36,6 +37,30 @@ k8s-ephemeral-storage-metrics:
     enable: true
     interval: 30s
     scrapeTimeout: 10s
+
+kubex-connector:
+  securityContext:
+    runAsUser: 1000750000
+    runAsGroup: 1000750000
+    fsGroup: 1000750000
+  containerSecurityContext:
+    capabilities:
+      drop:
+        - ALL
+    seccompProfile:
+      type: RuntimeDefault
+
+kubex-ai-cdi:
+  securityContext:
+    runAsUser: 1000750000
+    runAsGroup: 1000750000
+    fsGroup: 1000750000
+  containerSecurityContext:
+    capabilities:
+      drop:
+        - ALL
+    seccompProfile:
+      type: RuntimeDefault
 
 gpu-process-exporter:
   enabled: false

--- a/charts/kubex-automation-stack/values.yaml
+++ b/charts/kubex-automation-stack/values.yaml
@@ -6,6 +6,76 @@
 openshift:
   enabled: false
 
+rbac:
+  create: true
+  permissions:
+    cdi:
+      serviceAccount:
+        create: true
+        name: kubex-ai-cdi-sa
+      clusterRole:
+        create: true
+        name: kubex-ai-cdi-reader
+      clusterRoleBinding:
+        create: true
+        name: kubex-ai-cdi-reader
+      role:
+        create: false
+        name: kubex-ai-cdi-reader
+      roleBinding:
+        create: false
+        name: kubex-ai-cdi-reader
+      rules:
+        core:
+          enabled: true
+          resources: ["pods", "services", "configmaps", "namespaces", "nodes", "events"]
+          verbs: ["get", "list"]
+        podLogs:
+          enabled: true
+          resources: ["pods/log"]
+          verbs: ["get"]
+        workloads:
+          enabled: true
+          resources: ["deployments", "daemonsets", "statefulsets", "replicasets"]
+          verbs: ["get", "list"]
+        # Automatically enable OpenShift permissions when openshift mode is on.
+        openshift:
+          enabled: null
+          resources: ["machines", "machinesets", "machinedeployments", "machinehealthchecks", "controlplanemachinesets"]
+          verbs: ["get", "list"]
+        karpenter:
+          enabled: true
+          resources: ["nodepools", "nodeclaims"]
+          verbs: ["get", "list"]
+        karpenterAWS:
+          enabled: true
+          resources: ["ec2nodeclasses"]
+          verbs: ["get", "list"]
+        rollouts:
+          enabled: true
+          resources: ["rollouts", "analysisruns", "experiments"]
+          verbs: ["get", "list"]
+        kubexCRDs:
+          enabled: true
+          resources: ["automationstrategies", "clusterautomationstrategies", "clustergpurebalancingpolicies", "clusterproactivepolicies", "clusterrollbackpolicies", "clusterstaticpolicies", "globalconfigurations", "gpuconsolidationpolicies", "gpurebalancingpolicies", "podaffinitypolicies", "policyevaluations", "proactivepolicies", "rollbackpolicies", "staticpolicies"]
+          verbs: ["get", "list"]
+        selfSubjectReview:
+          enabled: true
+          resources: ["selfsubjectrulesreviews", "selfsubjectaccessreviews"]
+          verbs: ["create"]
+    connector:
+      serviceAccount:
+        create: false
+      clusterRole:
+        create: false
+      clusterRoleBinding:
+        create: false
+      role:
+        create: false
+      roleBinding:
+        create: false
+      rules: {}
+
 stack:
   densify:
     createSecret: true
@@ -17,6 +87,22 @@ gpu-process-exporter:
 
 node-labeler:
   enabled: false
+
+kubex-connector:
+  enabled: false
+  extraLabels: {}
+  extraAnnotations: {}
+  forwarderConfigMap:
+    name: kubex-kubex-stack
+  forwarderCredentialsSecretRef:
+    name: densify-api-secret
+
+kubex-ai-cdi:
+  enabled: false
+  extraLabels: {}
+  extraAnnotations: {}
+  rbac:
+    enabled: false
 
 container-optimization-data-forwarder:
   nameOverride: kubex-stack
@@ -34,6 +120,7 @@ container-optimization-data-forwarder:
       densify:
         url:
           UserSecretName: densify-api-secret
+    clusters: []
     prometheus:
       url:
         host: kubex-prometheus-server


### PR DESCRIPTION
Restores the kubex-automation-stack chart metadata and values changes on a dedicated branch.\n\nIncludes:\n- Chart.yaml version bump\n- Chart.lock Prometheus pin\n- README wording updates\n- values.yaml and values-edit.yaml stack entries